### PR TITLE
Collision detection fixes and some cleanup

### DIFF
--- a/src/constants/menuOptions.ts
+++ b/src/constants/menuOptions.ts
@@ -3,6 +3,8 @@ export class MenuOptions {
     public static COORDINATES = 'Coordinates';
     public static SCREEN_EDGE = 'Screen Edge';
     public static HITBOX = 'Hitbox';
+    public static ATTACK_HITBOX = 'Attack Hitbox';
+    public static ENEMY_HITBOX = 'Enemy Hitbox';
     public static DETECTION_BOX = 'Detection Box';
     public static DETECTED_TILES = 'Detected Tiles';
     public static COLLISION_TILES = 'Collision Tiles';
@@ -13,6 +15,8 @@ export class MenuOptions {
             this.COORDINATES,
             this.SCREEN_EDGE,
             this.HITBOX,
+            this.ATTACK_HITBOX,
+            this.ENEMY_HITBOX,
             this.DETECTION_BOX,
             this.DETECTED_TILES,
             this.COLLISION_TILES,

--- a/src/debug/debugMenu.ts
+++ b/src/debug/debugMenu.ts
@@ -76,6 +76,8 @@ export class DebugMenu {
         this.addMenuOption(menu, MenuOptions.GRID);
         this.addMenuOption(menu, MenuOptions.COORDINATES);
         this.addMenuOption(menu, MenuOptions.HITBOX);
+        this.addMenuOption(menu, MenuOptions.ATTACK_HITBOX);
+        this.addMenuOption(menu, MenuOptions.ENEMY_HITBOX);
         this.addMenuOption(menu, MenuOptions.DETECTION_BOX);
         this.addMenuOption(menu, MenuOptions.DETECTED_TILES);
         this.addMenuOption(menu, MenuOptions.COLLISION_TILES);

--- a/src/debug/debugMode.ts
+++ b/src/debug/debugMode.ts
@@ -46,13 +46,13 @@ export class DebugMode {
   }
 
   static drawDebugGraphics() {
-    this.drawScreenEdge();
-    this.drawDetectedTileOutlines();
-    this.drawCollisionDetectionBox();
+    // this.drawScreenEdge();
+    // this.drawDetectedTileOutlines();
+    // this.drawCollisionDetectionBox();
     this.drawHitbox();
     this.drawAttackHitbox();
     this.drawEnemyHitbox();
-    this.drawCollisionsOutlines();
+    // this.drawCollisionsOutlines();
     this.resetCtx();
   }
 

--- a/src/debug/debugMode.ts
+++ b/src/debug/debugMode.ts
@@ -5,6 +5,8 @@ import { StageTile } from '../objects/stageTile';
 import { MenuOptions } from '../constants/menuOptions';
 import { BuilderMode } from './builderMode';
 import { PropertiesMenu } from './propertiesMenu';
+import { Point } from '../interfaces/point';
+import { Dimensions } from '../interfaces/dimensions';
 
 export class DebugMode {
 
@@ -48,6 +50,8 @@ export class DebugMode {
     this.drawDetectedTileOutlines();
     this.drawCollisionDetectionBox();
     this.drawHitbox();
+    this.drawAttackHitbox();
+    this.drawEnemyHitbox();
     this.drawCollisionsOutlines();
     this.resetCtx();
   }
@@ -120,6 +124,38 @@ export class DebugMode {
       State.gameState.canvas.ctx.lineWidth = State.debugState.menuOptions[MenuOptions.HITBOX].lineWidth;
 
       const box = State.ninjaState.hitbox;
+      const { x, y } = RenderingUtilities.toScreenCoordinates(box.position);
+      const { w, h } = RenderingUtilities.toScreenDimensions(box.dimensions);
+      State.gameState.canvas.ctx.strokeRect(x, y, w, h);
+    }
+  }
+
+  static drawAttackHitbox() {
+    if (State.debugState.menuOptions[MenuOptions.ATTACK_HITBOX].enabled) {
+      State.gameState.canvas.ctx.strokeStyle = State.debugState.menuOptions[MenuOptions.ATTACK_HITBOX].color;
+      State.gameState.canvas.ctx.lineWidth = State.debugState.menuOptions[MenuOptions.ATTACK_HITBOX].lineWidth;
+
+      const box = State.ninjaState.hitbox;
+      if(State.ninjaState.attacking) {
+          let point: Point, dimensions: Dimensions;
+          if(State.ninjaState.movingRight) {
+              point = RenderingUtilities.toScreenCoordinates({x: box.position.x + box.dimensions.w - .5, y: box.position.y});
+              dimensions = RenderingUtilities.toScreenDimensions({w: 1, h: box.dimensions.h});
+          } else {
+              dimensions = RenderingUtilities.toScreenDimensions({w: 1, h: box.dimensions.h});
+              point = RenderingUtilities.toScreenCoordinates({x: box.position.x - .5, y: box.position.y});
+          }
+          State.gameState.canvas.ctx.strokeRect(point.x, point.y, dimensions.w, dimensions.h);
+      }
+    }
+  }
+
+  static drawEnemyHitbox() {
+    if (State.debugState.menuOptions[MenuOptions.ENEMY_HITBOX].enabled) {
+      State.gameState.canvas.ctx.strokeStyle = State.debugState.menuOptions[MenuOptions.ENEMY_HITBOX].color;
+      State.gameState.canvas.ctx.lineWidth = State.debugState.menuOptions[MenuOptions.ENEMY_HITBOX].lineWidth;
+
+      const box = State.enemyState.hitbox;
       const { x, y } = RenderingUtilities.toScreenCoordinates(box.position);
       const { w, h } = RenderingUtilities.toScreenDimensions(box.dimensions);
       State.gameState.canvas.ctx.strokeRect(x, y, w, h);

--- a/src/debug/propertiesMenu.ts
+++ b/src/debug/propertiesMenu.ts
@@ -64,8 +64,14 @@ export class PropertiesMenu {
       State.ninjaState.movementSpeed = Number((evt.target as HTMLInputElement).value);
     });
 
-    const input3 = this.addProperty(menu, 'Jump Speed', State.ninjaState.jumpSpeed);
+    const input3 = this.addProperty(menu, 'Movement Acceleration', State.ninjaState.movementAcceleration);
     input3.addEventListener('input', (evt) => {
+      console.log((evt.target as HTMLInputElement).value);
+      State.ninjaState.movementAcceleration = Number((evt.target as HTMLInputElement).value);
+    });
+
+    const input4 = this.addProperty(menu, 'Jump Speed', State.ninjaState.jumpSpeed);
+    input4.addEventListener('input', (evt) => {
       console.log((evt.target as HTMLInputElement).value);
       State.ninjaState.jumpSpeed = Number((evt.target as HTMLInputElement).value);
     });

--- a/src/engines/physicsEngine.ts
+++ b/src/engines/physicsEngine.ts
@@ -1,75 +1,10 @@
 import { State } from '../states/rootState';
 import { UpdateObject } from '../interfaces/updateObject';
-import { GridArea } from '../interfaces/gridArea';
 
 export class PhysicsEngine {
-
-    detectionArea: GridArea;
-
-    constructor() {
-    }
-
     run() {
-        this.detectCollision();
         State.gameState.assets.forEach((asset: UpdateObject) => {
             asset.updateProperties(State.gameState.keys);
         });
-    }
-
-    detectCollision() {
-        this.getTilesInDetectionArea();
-        State.stageState.collisionTiles = [];
-        const tilesToCheck = State.stageState.detectionTiles;
-        const hitbox = State.ninjaState.hitbox;
-
-        for (const tile of tilesToCheck) {
-
-            if (hitbox.position.x <= tile.col + 1.0 &&                     // TL.x of hitbox < TR.x of tile
-                hitbox.position.x + hitbox.dimensions.w >= tile.col &&   // TR.x of hitbox > TL.x of tile
-                hitbox.position.y + 1 >= tile.row &&                     // TL.y of hitbox < BL.y of tile
-                hitbox.position.y - hitbox.dimensions.h <= tile.row) {   // BL.y of hitbox > TL.y of tile
-                State.stageState.collisionTiles.push(tile);
-            }
-        }
-    }
-
-    getDetectionArea(): void {
-        const box = State.ninjaState.collisionDetectionBox;
-        this.detectionArea = {
-            topLeft: box.position,
-            topRight: {
-                x: box.position.x + box.dimensions.w,
-                y: box.position.y
-            },
-            bottomLeft: {
-                x: box.position.x,
-                y: box.position.y - box.dimensions.h
-            },
-            bottomRight: {
-                x: box.position.x + box.dimensions.w,
-                y: box.position.y - box.dimensions.h
-            }
-        };
-    }
-
-    getTilesInDetectionArea(): void {
-        this.getDetectionArea();
-        State.stageState.detectionTiles = [];
-
-        const topLeftY = Math.floor(this.detectionArea.topLeft.y);
-        const bottomLeftY = Math.floor(this.detectionArea.bottomLeft.y);
-        const topLeftX = Math.floor(this.detectionArea.topLeft.x);
-        const topRightX = Math.floor(this.detectionArea.topRight.x);
-
-        for (let row = bottomLeftY + 1; row <= topLeftY + 1; row++) {
-            for (let col = topLeftX; col <= topRightX; col++) {
-                if (row < 0 || col < 0) { continue; }
-
-                const tile = State.stageState.tiles.get(`${col}-${row}`);
-                if (tile && tile.lookupValue !== '00') {
-                    State.stageState.detectionTiles.push(tile);
-                }
-            }
-        }
     }
 }

--- a/src/engines/renderingEngine.ts
+++ b/src/engines/renderingEngine.ts
@@ -6,8 +6,6 @@ import { RenderingUtilities } from '../utilites/renderingUtilities';
 
 export class RenderingEngine {
 
-    constructor() { }
-
     run() {
         RenderingUtilities.refreshCanvas();
 

--- a/src/objects/canvas.ts
+++ b/src/objects/canvas.ts
@@ -7,6 +7,7 @@ export class CanvasElement {
     this.canvasElement.id = id;
     this.canvasElement.width = width;
     this.canvasElement.height = height;
+    this.canvasElement.oncontextmenu = () => false; // disabling context menu for right click, as the right click may become a key-binding in future (throwing daggers)
     this.ctx = this.canvasElement.getContext('2d');
   }
 }

--- a/src/objects/game.ts
+++ b/src/objects/game.ts
@@ -87,8 +87,8 @@ export class Game {
     canvas.addEventListener('mousemove', (evt: MouseEvent) => BuilderMode.handleMouseMove(evt));
     canvas.addEventListener('mousedown', (evt: MouseEvent) => BuilderMode.handleMouseClick(evt, true));
     canvas.addEventListener('mouseup', (evt: MouseEvent) => BuilderMode.handleMouseClick(evt, false));
-      canvas.addEventListener('mousedown', (evt: MouseEvent) => this.parseKey(evt.type, true));
-      canvas.addEventListener('mouseup', (evt: MouseEvent) => this.parseKey(evt.type, false));
+    canvas.addEventListener('mousedown', (evt: MouseEvent) => {if(evt.button === 0 ) this.parseKey(evt.type, true)});
+    canvas.addEventListener('mouseup', (evt: MouseEvent) => {if(evt.button === 0 ) this.parseKey(evt.type, false)});
 
     window.onresize = () => RenderingUtilities.debounce(RenderingUtilities.resizeScreenDimensions, window);
   }

--- a/src/objects/ninja.ts
+++ b/src/objects/ninja.ts
@@ -79,10 +79,13 @@ export class Ninja implements UpdateObject {
         }
 
         const updatedVelocity = CollisionUtilities.collideWithTiles(this.state.hitbox, velocity);
-        this.state.velocity = updatedVelocity;
 
         this.state.position.x += updatedVelocity.dx;
         this.state.position.y += updatedVelocity.dy;
+        this.state.position = CollisionUtilities.roundPosition(this.state.position);
+
+        this.state.velocity.dx = velocity.dx != updatedVelocity.dx ? 0 : updatedVelocity.dx;
+        this.state.velocity.dy = velocity.dy != updatedVelocity.dy ? 0 : updatedVelocity.dy;
 
         // To remove repetitive jumping when key is held
         this.state.jumpUsed = up;
@@ -130,6 +133,8 @@ export class Ninja implements UpdateObject {
             x: this.state.position.x - this.state.hitbox.dimensions.w/2,
             y: this.state.position.y - this.state.hitboxOffset.h
         };
+        this.state.hitbox.position = CollisionUtilities.roundPosition(this.state.hitbox.position);
+
         this.state.collisionDetectionBox.position = {
             x: this.state.position.x - 2 - this.state.hitbox.dimensions.w/2,
             y: this.state.position.y + 2

--- a/src/objects/ninja.ts
+++ b/src/objects/ninja.ts
@@ -70,7 +70,8 @@ export class Ninja implements UpdateObject {
             velocity.dy += this.state.jumpSpeed;
         }
         if (right !== left) {
-            velocity.dx = right ? this.state.movementSpeed : -this.state.movementSpeed;
+            const speed = this.state.velocity.dx + (right ? this.state.movementAcceleration : -this.state.movementAcceleration);
+            velocity.dx = speed < 0 ? Math.max(speed, -this.state.movementSpeed) : Math.min(speed, this.state.movementSpeed);
         }
         if (velocity.dy > -this.state.terminalVelocity) {
             velocity.dy -= this.state.gravity;

--- a/src/objects/ninja.ts
+++ b/src/objects/ninja.ts
@@ -70,7 +70,8 @@ export class Ninja implements UpdateObject {
             velocity.dy += this.state.jumpSpeed;
         }
         if (right !== left) {
-            const speed = this.state.velocity.dx + (right ? this.state.movementAcceleration : -this.state.movementAcceleration);
+            const movingRight = this.state.velocity.dx > 0;
+            const speed = right != movingRight && this.state.velocity.dx !== 0 ? 0 : this.state.velocity.dx + (right ? this.state.movementAcceleration : -this.state.movementAcceleration);
             velocity.dx = speed < 0 ? Math.max(speed, -this.state.movementSpeed) : Math.min(speed, this.state.movementSpeed);
         }
         if (velocity.dy > -this.state.terminalVelocity) {

--- a/src/states/debugState.ts
+++ b/src/states/debugState.ts
@@ -22,11 +22,14 @@ export class DebugState {
             this.menuOptions = JSON.parse(menuOptionsJson);
         } else {
             this.menuOptions = {};
-            MenuOptions.getOptionList().forEach((optionName: string) => {
+        }
+
+        MenuOptions.getOptionList().forEach((optionName: string) => {
+            if(!this.menuOptions[optionName]) {
                 const option = new MenuOption(optionName);
                 this.menuOptions[optionName] = option;
-            });
-            this.menuOptions[MenuOptions.COORDINATES].lineWidth = null;
-        }
+            }
+        });
+        this.menuOptions[MenuOptions.COORDINATES].lineWidth = null;
     }
 }

--- a/src/states/ninjaState.ts
+++ b/src/states/ninjaState.ts
@@ -48,7 +48,7 @@ export class NinjaState {
         this.movingRight = true;
         this.position = { x: 18, y: 7 };
         this.movementSpeed = .25;
-        this.movementAcceleration = .01;
+        this.movementAcceleration = .02;
         this.gravity = .05;
         this.velocity = { dx: 0, dy: 0 };
         this.terminalVelocity = .75;

--- a/src/states/ninjaState.ts
+++ b/src/states/ninjaState.ts
@@ -24,6 +24,7 @@ export class NinjaState {
     movingRight: boolean;
     position: Point;
     movementSpeed: number;
+    movementAcceleration: number;
     // TODO: Gravity should be in the gameState, and it should effect a characters mass
     gravity: number;
     velocity: Velocity;
@@ -47,6 +48,7 @@ export class NinjaState {
         this.movingRight = true;
         this.position = { x: 18, y: 7 };
         this.movementSpeed = .25;
+        this.movementAcceleration = .01;
         this.gravity = .05;
         this.velocity = { dx: 0, dy: 0 };
         this.terminalVelocity = .75;

--- a/src/utilites/collisionUtilities.ts
+++ b/src/utilites/collisionUtilities.ts
@@ -127,4 +127,16 @@ export class CollisionUtilities {
         return detectionTiles;
     }
 
+    /**
+     * Round to 2 decimal places. This is a utility helper method that can be used to help resolve some of the precision issues with hitbox detection.
+     * @param x
+     * @param y
+     */
+    static roundPosition({x, y}: Point): Point {
+        return {
+            x: Math.round((x + Number.EPSILON) * 100) / 100,
+            y: Math.round((y + Number.EPSILON) * 100) / 100
+        }
+    }
+
 }

--- a/src/utilites/collisionUtilities.ts
+++ b/src/utilites/collisionUtilities.ts
@@ -74,6 +74,11 @@ export class CollisionUtilities {
         return velocity;
     }
 
+    /**
+     * Get a box that is the original box combined with the given velocity.
+     * @param hitbox
+     * @param movement
+     */
     static getDetectionArea(hitbox: Box, movement: Velocity) : Box {
         return {
             position: {
@@ -90,7 +95,7 @@ export class CollisionUtilities {
     /**
      * Check to see if two ranges overlap
      * Requires range a to follow: a1 < a2
-     * and range b to follow and b1 < b2
+     * and range b to follow: b1 < b2
      */
     static hasOverlap(a1: number, a2: number, b1: number, b2: number): boolean {
         return Math.max(a1, b1) < Math.min(a2, b2);


### PR DESCRIPTION
## Changes

 - added acceleration to movement to allow for more precise movements
 - added acceleration as an option in the properties menu
 - add hitbox display for both the enemy and the ninja attacks
 - added hitbox display option in the debug menu
 - disabled the old hitbox code that is no longer being used
 - fixed collision detection by adding rounding where necessary

## References

 - https://github.com/BadassBison/Bokudos/issues/41 - this items should all be fixed now with the rounding fix

## Screenshots

These changes fixed the previous issues with collision, but it seems to have introduced this new issue where you can get stuck on the corner of a tile if timed just right. I am looking into it.
![image](https://user-images.githubusercontent.com/47049368/103811915-49f80300-5023-11eb-889d-70337fc60774.png)
